### PR TITLE
REFACTOR: Replace tqdm for License Compatibility

### DIFF
--- a/pacsifier/cli/add_karnak_tags.py
+++ b/pacsifier/cli/add_karnak_tags.py
@@ -19,7 +19,7 @@ import sys
 import pydicom
 from glob import glob
 import os
-from tqdm import tqdm
+from progressbar import ProgressBar
 import json
 from typing import Dict
 import argparse
@@ -104,7 +104,8 @@ def tag_all_dicoms_within_root_folder(
     # TODO add Cerberus validation on album_name and newid - both should be DICOM VR LO
 
     # Loop over patients...
-    for patient in tqdm(patients_folders):
+    progress = ProgressBar()
+    for patient in progress(patients_folders):
         new_id = old2new_idx[patient]
         patient_shift = personal_day_shift[patient]
         current_path = os.path.join(data_path, patient, pattern_dicom_files)

--- a/pacsifier/cli/anonymize_dicoms.py
+++ b/pacsifier/cli/anonymize_dicoms.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 from glob import glob
 import os
 import warnings
-from tqdm import tqdm
+from progressbar import ProgressBar
 import random
 import json
 from typing import Dict, Tuple
@@ -379,7 +379,8 @@ def anonymize_all_dicoms_within_root_folder(
     old2set_idx = {}
 
     # Loop over patients...
-    for patient_index, patient in enumerate(tqdm(patients_folders)):
+    progress = ProgressBar()
+    for patient_index, patient in enumerate(progress(patients_folders)):
         new_id = old2new_idx[patient]
         current_path = os.path.join(datapath, patient, pattern_dicom_files)
 

--- a/pacsifier/cli/pacsifier.py
+++ b/pacsifier/cli/pacsifier.py
@@ -19,7 +19,6 @@ import re
 import shutil
 import unicodedata
 import sys
-from tqdm import tqdm
 import os
 import warnings
 from pandas import read_csv, DataFrame
@@ -27,6 +26,7 @@ from pandas.errors import ParserError
 import json
 from typing import Iterator, Dict, List
 from cerberus import Validator
+from progressbar import ProgressBar
 import csv
 import time
 import argparse
@@ -365,7 +365,8 @@ def retrieve_dicoms_using_table(
         my_re_clean = re.compile("[^0-9a-zA-Z]+")  # keep only alphanums
 
         # loop over series
-        for serie in tqdm(series):
+        progress = ProgressBar()
+        for serie in progress(series):
             # replace illegal chars with underscores
             patientID_sanitized = my_re_clean.sub(
                 "_",
@@ -595,7 +596,8 @@ def upload_dicoms(dicom_dir: str, parameters: Dict[str, str]) -> None:
                     series_log_dirs.append(sub_dir_log_path)
 
         # Loop over all series
-        for series_dir, series_log_dir in tqdm(zip(series_dirs, series_log_dirs)):
+        progress = ProgressBar()
+        for series_dir, series_log_dir in progress(zip(series_dirs, series_log_dirs)):
             counter += 1
             if counter % batch_size == 0:
                 time.sleep(batch_wait_time)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =  # file:requirements.txt
     hypothesis == 6.98
     nibabel == 5.2
     pydicom == 2.4
-    tqdm == 4.66
+    progressbar2 == 3.55
     beautifulsoup4 == 4.12
     jsonschema == 4.21
 test_requires =


### PR DESCRIPTION
Replace tqdm with progressbar2 (BSD License) for progress tracking, ensuring license compatibility with Apache 2.0
closes #16